### PR TITLE
Store cache on portal instead of the realm.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Store cache on portal instead of the realm. [mbaechtold]
+
 - Add a new statistics view which lists objects existing on the remote
   system (receiver) but not on the local system (sender). [mbaechtold]
 

--- a/ftw/publisher/controlling/browser/receiver/jsonviews.py
+++ b/ftw/publisher/controlling/browser/receiver/jsonviews.py
@@ -1,5 +1,6 @@
 from DateTime import DateTime
 from Products.Five import BrowserView
+from datetime import datetime
 import simplejson
 
 
@@ -64,6 +65,8 @@ class ListRemoteObjects(BrowserView):
                     value = value()
                 except TypeError:
                     pass
+            if isinstance(value, datetime):
+                value = DateTime(value)
             if isinstance(value, DateTime):
                 value = value.ISO8601()
             data[name] = value

--- a/ftw/publisher/controlling/browser/sender/views.py
+++ b/ftw/publisher/controlling/browser/sender/views.py
@@ -144,6 +144,8 @@ class BaseStatistic(BrowserView):
     def translate_workflow_state(self, workflow_id, state_id):
         wftool = getToolByName(self.context, 'portal_workflow')
         workflow = wftool.get(workflow_id)
+        if not workflow:
+            return state_id
         state = workflow.states.get(state_id)
         if state:
             return translate(state.title.decode('utf-8'),
@@ -154,6 +156,8 @@ class BaseStatistic(BrowserView):
     def translate_workflow_name(self, workflow_id):
         wftool = getToolByName(self.context, 'portal_workflow')
         workflow = wftool.get(workflow_id)
+        if not workflow:
+            return workflow_id
         return translate(workflow.title.decode('utf-8'),
                          domain='plone',
                          context=self.request).encode('utf-8')


### PR DESCRIPTION
This is needed due to `OverridenRealm` from `ftw.publisher.sender` not being able to store data in annotations.
  